### PR TITLE
enable user-selection on text by default

### DIFF
--- a/src/renderer/src/theme/index.ts
+++ b/src/renderer/src/theme/index.ts
@@ -57,48 +57,36 @@ declare module '@mui/material/styles' {
   }
 }
 
-const defaultTextStyles = {
-  userSelect: 'none' as React.CSSProperties['userSelect'],
-}
-
 export const theme = createTheme({
   typography: {
     h1: {
       fontSize: 40,
       fontWeight: 700,
       color: MIDNIGHT_BLUE,
-      ...defaultTextStyles,
     },
     h2: {
       fontSize: 30,
       fontWeight: 400,
       color: MIDNIGHT_BLUE,
-      ...defaultTextStyles,
     },
     h3: {
       fontSize: 26,
       fontWeight: 400,
       color: MIDNIGHT_BLUE,
-      ...defaultTextStyles,
     },
     h4: {
       fontSize: 24,
       fontWeight: 300,
       color: MIDNIGHT_BLUE,
-      ...defaultTextStyles,
     },
     h5: {
       fontSize: 18,
       fontWeight: 300,
       color: MIDNIGHT_BLUE,
-      ...defaultTextStyles,
     },
-    body1: {
-      ...defaultTextStyles,
-    },
+    body1: {},
     caption: {
       color: GREY,
-      ...defaultTextStyles,
     },
     fontFamily: [
       'Rubik',


### PR DESCRIPTION
Don't have the full context but would interested as to why this is disabled for all text. Not being able to select _any_ text doesn't seem like a good default. Most of MUI's components disable it where appropriate and if there's a case that it doesn't cover, we should explicitly set this in the relevant scope.