### PR TITLE
implement initial device invite modal

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -38,6 +38,27 @@
   "views.Home.Settings.ProjectConfig.ConfigSection.projectName": {
     "message": "Project Name"
   },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.cancel": {
+    "message": "Cancel"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.learnMore": {
+    "message": "Learn more"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.noDevicePrompt": {
+    "message": "Not seeing a device?"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.noDeviceSuggestion1": {
+    "message": "Make sure both devices are on the same wifi network"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.noDeviceSuggestion2": {
+    "message": "Make sure both devices are on the same version of Mapeo"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.selectDevice": {
+    "message": "Select a device to invite"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.title": {
+    "message": "Invite Device"
+  },
   "views.Home.Settings.ProjectConfig.ManageTeamSection.coordinator": {
     "message": "Coordinators"
   },

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/Button.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/Button.tsx
@@ -14,18 +14,22 @@ export const ButtonText = ({ children }: React.PropsWithChildren<{}>) => {
 
 export const Button = ({
   children,
+  noBorder,
+  sx,
   ...muiButtonProps
-}: React.PropsWithChildren<React.ComponentProps<typeof MuiButton>>) => {
+}: React.PropsWithChildren<React.ComponentProps<typeof MuiButton> & { noBorder?: boolean }>) => {
   const theme = useTheme()
+
   return (
     <MuiButton
       {...muiButtonProps}
       sx={{
         backgroundColor: theme.white,
-        border: `1px solid ${theme.grey.light}`,
+        border: `1px solid ${noBorder ? 'transparent' : theme.grey.light}`,
         borderRadius: '6px',
         paddingY: spacing.medium,
         paddingX: spacing.large,
+        ...sx,
       }}
     >
       {typeof children === 'string' ? <ButtonText>{children}</ButtonText> : children}

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import styled from '@emotion/styled'
 import { Dialog, DialogActions, DialogContent, DialogTitle, useTheme } from '@mui/material'
@@ -11,32 +10,27 @@ import { Text } from './Text'
 import { Button } from './Button'
 import { PeerCard } from './PeerCard'
 import { PressableText } from './PressableText'
-import { Peer } from '.'
+import { useMapeoDeviceNonMembersListIds } from '@renderer/hooks/useMapeoDeviceList'
+import { useMapeoDevice } from '@renderer/hooks/useMapeoDevice'
+import { Device } from '@renderer/hooks/stores/mapeoDeviceStore'
 
-interface Props {
-  open: boolean
-  onClose: () => void
+const NonMemberPeerCard = ({ id, onClick }: { id: string; onClick: (d: Device) => void }) => {
+  const { device } = useMapeoDevice(id)
+  return (
+    <PeerCard
+      title={device.name}
+      subtitle={device.deviceId}
+      deviceType={device.deviceType}
+      onClick={() => onClick(device)}
+    />
+  )
 }
 
-export const InviteDeviceModal = ({ open, onClose }: Props) => {
+export const InviteDeviceModal = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
   const { formatMessage: t } = useIntl()
   const theme = useTheme()
 
-  const [peers] = React.useState<Peer[]>(() => {
-    return Array(10)
-      .fill(null)
-      .map((_, index) => {
-        const displayedNumber = index + 1
-        const deviceType = Math.random() > 0.75 ? 'desktop' : 'mobile'
-
-        return {
-          id: `peer-${displayedNumber}`,
-          deviceType,
-          name: `Peer ${displayedNumber} `,
-          deviceId: `${deviceType === 'desktop' ? 'Desktop' : 'Android'} Device ${displayedNumber}`,
-        }
-      })
-  })
+  const nonMemberDevices = useMapeoDeviceNonMembersListIds()
 
   return (
     <Dialog
@@ -94,14 +88,8 @@ export const InviteDeviceModal = ({ open, onClose }: Props) => {
             flex={1}
             spacing={spacing.medium}
           >
-            {peers.map((p) => (
-              <PeerCard
-                key={p.id}
-                title={p.name}
-                subtitle={p.deviceId}
-                deviceType={p.deviceType}
-                onClick={() => {}}
-              />
+            {nonMemberDevices.map((id) => (
+              <NonMemberPeerCard key={id} id={id} onClick={() => {}} />
             ))}
           </Column>
         </Row>

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react'
+import { defineMessages, useIntl } from 'react-intl'
+import styled from '@emotion/styled'
+import { Dialog, DialogActions, DialogContent, DialogTitle, useTheme } from '@mui/material'
+import LaunchIcon from '@mui/icons-material/Launch'
+import WifiIcon from '@mui/icons-material/Wifi'
+import { Column, Row } from '@renderer/components/LayoutComponents'
+import { spacing } from '@renderer/theme/spacing'
+
+import { Text } from './Text'
+import { Button } from './Button'
+import { PeerCard } from './PeerCard'
+import { PressableText } from './PressableText'
+import { Peer } from '.'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export const InviteDeviceModal = ({ open, onClose }: Props) => {
+  const { formatMessage: t } = useIntl()
+  const theme = useTheme()
+
+  const [peers] = React.useState<Peer[]>(() => {
+    return Array(10)
+      .fill(null)
+      .map((_, index) => {
+        const displayedNumber = index + 1
+        const deviceType = Math.random() > 0.75 ? 'desktop' : 'mobile'
+
+        return {
+          id: `peer-${displayedNumber}`,
+          deviceType,
+          name: `Peer ${displayedNumber} `,
+          deviceId: `${deviceType === 'desktop' ? 'Desktop' : 'Android'} Device ${displayedNumber}`,
+        }
+      })
+  })
+
+  return (
+    <Dialog
+      open={open}
+      onClose={(_, reason) => {
+        if (reason === 'backdropClick' || reason === 'escapeKeyDown') return
+        onClose()
+      }}
+      fullScreen
+      sx={{ margin: '48px' }}
+    >
+      <Row
+        borderBottom={`1px solid ${theme.grey.light}`}
+        padding={spacing.large}
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <DialogTitle fontWeight="600" fontSize="24px" sx={{ padding: 0 }}>
+          {t(m.title)}
+        </DialogTitle>
+        <Row>
+          {/* TODO: Use actual Wifi info */}
+          <WifiIcon sx={{ marginInlineEnd: spacing.small }} />
+          <Text size="small" fontWeight="500" color={theme.blue.dark}>
+            SpicyWifi - 5G
+          </Text>
+        </Row>
+      </Row>
+      <DialogContent sx={{ display: 'flex', padding: 0 }}>
+        <Row flex={1}>
+          <Column padding={spacing.large} maxWidth="400px" spacing={spacing.medium}>
+            <Text size="medium" fontWeight="500">
+              {t(m.selectDevice)}
+            </Text>
+            <Text size="medium">{t(m.noDevicePrompt)}</Text>
+            <StyledList>
+              <Column spacing={spacing.medium}>
+                <li>
+                  <Text size="medium">{t(m.noDeviceSuggestion1)}</Text>
+                </li>
+                <li>
+                  <Text size="medium">{t(m.noDeviceSuggestion2)}</Text>
+                </li>
+              </Column>
+            </StyledList>
+            <Row>
+              {/* TODO: Probably should be a link */}
+              <PressableText onClick={() => {}} Icon={LaunchIcon} iconPosition="end">
+                {t(m.learnMore)}
+              </PressableText>
+            </Row>
+          </Column>
+          <Column
+            sx={{ backgroundColor: theme.background, overflow: 'auto', padding: spacing.large }}
+            flex={1}
+            spacing={spacing.medium}
+          >
+            {peers.map((p) => (
+              <PeerCard
+                key={p.id}
+                title={p.name}
+                subtitle={p.deviceId}
+                deviceType={p.deviceType}
+                onClick={() => {}}
+              />
+            ))}
+          </Column>
+        </Row>
+      </DialogContent>
+      <DialogActions sx={{ borderTop: `1px solid ${theme.grey.light}`, paddingX: spacing.large }}>
+        <Button noBorder onClick={onClose}>
+          {t(m.cancel)}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+const StyledList = styled.ul(`
+  list-style: disc;
+  padding-inline-start: ${spacing.large};
+`)
+
+const m = defineMessages({
+  title: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.title',
+    defaultMessage: 'Invite Device',
+  },
+  selectDevice: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.selectDevice',
+    defaultMessage: 'Select a device to invite',
+  },
+  noDevicePrompt: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.noDevicePrompt',
+    defaultMessage: 'Not seeing a device?',
+  },
+  noDeviceSuggestion1: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.noDeviceSuggestion1',
+    defaultMessage: 'Make sure both devices are on the same wifi network',
+  },
+  noDeviceSuggestion2: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.noDeviceSuggestion2',
+    defaultMessage: 'Make sure both devices are on the same version of Mapeo',
+  },
+  learnMore: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.learnMore',
+    defaultMessage: 'Learn more',
+  },
+  cancel: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.cancel',
+    defaultMessage: 'Cancel',
+  },
+})

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal.tsx
@@ -52,10 +52,9 @@ export const InviteDeviceModal = ({ open, onClose }: { open: boolean; onClose: (
           {t(m.title)}
         </DialogTitle>
         <Row>
-          {/* TODO: Use actual Wifi info */}
           <WifiIcon sx={{ marginInlineEnd: spacing.small }} />
           <Text size="small" fontWeight="500" color={theme.blue.dark}>
-            SpicyWifi - 5G
+            MiWifi - 5G
           </Text>
         </Row>
       </Row>

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/ManageTeamSection.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/ManageTeamSection.tsx
@@ -9,11 +9,10 @@ import { spacing } from '@renderer/theme/spacing'
 import { MemberDevice } from '@renderer/hooks/stores/mapeoDeviceStore'
 import { useMapeoDeviceMembers } from '@renderer/hooks/useMapeoMembersList'
 
-import desktopImageUrl from '../../../../../assets/desktop.png'
-import mobileImageUrl from '../../../../../assets/mobile.png'
 import { PressableText } from './PressableText'
 import { Text } from './Text'
 import { Button, ButtonText } from './Button'
+import { PeerCard } from './PeerCard'
 
 const m = defineMessages({
   title: {
@@ -58,50 +57,25 @@ const BlackSquarePlaceholder = styled.div(
 
 const MemberCard = ({ member }: { member: MemberDevice }) => {
   const { formatMessage: t } = useIntl()
-  const theme = useTheme()
+
   return (
-    <Row
-      padding={spacing.large}
-      alignItems="center"
-      sx={{
-        maxWidth: '400px',
-        minWidth: '300px',
-        backgroundColor: theme.white,
-        borderRadius: '6px',
-        border: `1px solid ${theme.grey.light}`,
-      }}
-    >
-      <Column marginRight={spacing.medium}>
-        <img
-          src={member.deviceType === 'desktop' ? desktopImageUrl : mobileImageUrl}
-          style={{ display: 'block', maxWidth: '100%', width: '40px' }}
-        />
-      </Column>
-      <Column flex={1}>
-        <Row justifyContent="space-between">
-          <Text size="small" fontWeight="600">
-            {member.name}
-          </Text>
-          <Text size="small" color={theme.grey.main}>
-            {new Date(member.dateAdded).toLocaleDateString()}
-          </Text>
-        </Row>
-        <Row justifyContent="space-between">
-          <Text size="small" color={theme.grey.main}>
-            {member.isSelf ? t(m.thisDevice) : member.deviceId}
-          </Text>
-          {member.isSelf && (
-            <PressableText destructive onClick={() => {}}>
-              {t(m.leaveProject)}
-            </PressableText>
-          )}
-        </Row>
-      </Column>
-    </Row>
+    <PeerCard
+      deviceType={member.deviceType}
+      title={member.name}
+      subtitle={member.isSelf ? t(m.thisDevice) : member.deviceId}
+      dateText={new Date(member.dateAdded).toLocaleDateString()}
+      pressableAction={
+        member.isSelf ? (
+          <PressableText destructive onClick={() => {}}>
+            {t(m.leaveProject)}
+          </PressableText>
+        ) : undefined
+      }
+    />
   )
 }
 
-export const ManageTeamSection = () => {
+export const ManageTeamSection = ({ onInviteClick }: { onInviteClick: () => void }) => {
   const { formatMessage: t } = useIntl()
   const theme = useTheme()
 
@@ -138,7 +112,7 @@ export const ManageTeamSection = () => {
           </Row>
         </Column>
         <Row>
-          <Button variant="outlined" onClick={() => {}}>
+          <Button variant="outlined" onClick={onInviteClick}>
             <Row spacing={spacing.small} alignItems="center">
               <PersonAddIcon sx={{ fontSize: '18px' }} />
               <ButtonText>{t(m.invite)}</ButtonText>

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/PeerCard.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/PeerCard.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+import { useTheme } from '@mui/material'
+import { Column, Row } from '@renderer/components/LayoutComponents'
+import { spacing } from '@renderer/theme/spacing'
+
+import desktopImageUrl from '../../../../../assets/desktop.png'
+import mobileImageUrl from '../../../../../assets/mobile.png'
+import { Button } from './Button'
+import { Text } from './Text'
+import { Peer } from '.'
+
+const SHARED_CONTAINER_STYLES = {
+  maxWidth: '400px',
+  minWidth: '300px',
+  borderRadius: '6px',
+  padding: spacing.large,
+}
+
+const Container = ({ pressable, children }: React.PropsWithChildren<{ pressable?: boolean }>) => {
+  const theme = useTheme()
+
+  return pressable ? (
+    <Button sx={SHARED_CONTAINER_STYLES}>{children}</Button>
+  ) : (
+    <Row
+      padding={spacing.large}
+      alignItems="center"
+      sx={{
+        ...SHARED_CONTAINER_STYLES,
+        backgroundColor: theme.white,
+        border: `1px solid ${theme.grey.light}`,
+      }}
+    >
+      {children}
+    </Row>
+  )
+}
+
+interface Props {
+  dateText?: string
+  deviceType: Peer['deviceType']
+  pressableAction?: React.ReactNode
+  subtitle?: string
+  title: string
+  onClick?: () => void
+}
+
+export const PeerCard = ({ dateText, deviceType, pressableAction, subtitle, title, onClick }: Props) => {
+  const theme = useTheme()
+  return (
+    <Container pressable={!!onClick}>
+      <Column marginRight={spacing.medium}>
+        <img
+          src={deviceType === 'desktop' ? desktopImageUrl : mobileImageUrl}
+          style={{ display: 'block', maxWidth: '100%', width: '40px' }}
+        />
+      </Column>
+      <Column flex={1}>
+        <Row justifyContent="space-between">
+          <Text size="small" fontWeight="600">
+            {title}
+          </Text>
+          {dateText && (
+            <Text size="small" color={theme.grey.main}>
+              {dateText}
+            </Text>
+          )}
+        </Row>
+        <Row justifyContent="space-between">
+          {subtitle && (
+            <Text size="small" color={theme.grey.main}>
+              {subtitle}
+            </Text>
+          )}
+          {pressableAction}
+        </Row>
+      </Column>
+    </Container>
+  )
+}

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/PeerCard.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/PeerCard.tsx
@@ -2,12 +2,12 @@ import * as React from 'react'
 import { useTheme } from '@mui/material'
 import { Column, Row } from '@renderer/components/LayoutComponents'
 import { spacing } from '@renderer/theme/spacing'
+import { Device } from '@renderer/hooks/stores/mapeoDeviceStore'
 
 import desktopImageUrl from '../../../../../assets/desktop.png'
 import mobileImageUrl from '../../../../../assets/mobile.png'
 import { Button } from './Button'
 import { Text } from './Text'
-import { Peer } from '.'
 
 const SHARED_CONTAINER_STYLES = {
   maxWidth: '400px',
@@ -38,7 +38,7 @@ const Container = ({ pressable, children }: React.PropsWithChildren<{ pressable?
 
 interface Props {
   dateText?: string
-  deviceType: Peer['deviceType']
+  deviceType: Device['deviceType']
   pressableAction?: React.ReactNode
   subtitle?: string
   title: string

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/PressableText.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/PressableText.tsx
@@ -6,45 +6,60 @@ import { spacing } from '@renderer/theme/spacing'
 import { Text } from './Text'
 import type { SvgIconComponent } from '@mui/icons-material'
 
-const IconContainer = styled.span(`
+type IconPosition = 'start' | 'end'
+
+const IconContainer = styled.span<{ position: IconPosition }>(
+  ({ position }) => `
   line-height: 0;
-  margin-inline-end: ${spacing.small};
+  margin-inline-${position === 'start' ? 'end' : 'start'}: ${spacing.small};
   font-size: 18px;
-`)
+`,
+)
 
 export const PressableText = ({
-  Icon,
   children,
   destructive,
+  Icon,
+  iconPosition = 'start',
   onClick,
 }: React.PropsWithChildren<{
   destructive?: boolean
-  Icon?: SvgIconComponent
   onClick: () => void
+  Icon?: SvgIconComponent
+  iconPosition?: IconPosition
 }>) => {
+  const spacingStyles = {
+    padding: 0,
+    [iconPosition === 'start' ? 'marginRight' : 'marginLeft']: '-4px',
+    [iconPosition === 'start' ? 'paddingRight' : 'paddingLeft']: spacing.small,
+  }
+
   return (
     <Button
       color={destructive ? 'warning' : 'primary'}
       variant="text"
       onClick={onClick}
       sx={{
+        ...spacingStyles,
         justifyContent: 'flex-start',
-        padding: 0,
         alignItems: 'center',
         textTransform: 'none',
-        marginRight: '-4px',
-        paddingRight: spacing.small,
         minWidth: 0,
       }}
     >
-      {Icon ? (
-        <IconContainer>
+      {Icon && iconPosition === 'start' ? (
+        <IconContainer position="start">
           <Icon fontSize="inherit" />
         </IconContainer>
       ) : null}
       <Text size="small" color="inherit" fontWeight="500">
         {children}
       </Text>
+      {Icon && iconPosition === 'end' ? (
+        <IconContainer position="end">
+          <Icon fontSize="inherit" />
+        </IconContainer>
+      ) : null}
     </Button>
   )
 }

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/index.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/index.tsx
@@ -8,6 +8,7 @@ import { Button } from './Button'
 import { ConfigSection } from './ConfigSection'
 import { ManageTeamSection } from './ManageTeamSection'
 import { Text } from './Text'
+import { InviteDeviceModal } from './InviteDeviceModal'
 
 const m = defineMessages({
   title: {
@@ -41,11 +42,14 @@ const HeaderSection = () => {
 }
 
 export const ProjectConfig = () => {
+  const [inviteModalOpen, setInviteModalOpen] = React.useState(false)
+
   return (
     <Box display="flex" justifyContent="flex-start" flexDirection="column" flex={1}>
+      <InviteDeviceModal open={inviteModalOpen} onClose={() => setInviteModalOpen(false)} />
       <HeaderSection />
       <ConfigSection />
-      <ManageTeamSection />
+      <ManageTeamSection onInviteClick={() => setInviteModalOpen(true)} />
     </Box>
   )
 }


### PR DESCRIPTION
Closes #25 

**Note that this is stacked on #41**

Notes:

- wifi info is hardcoded at the moment. do we want to provide actual info?
- ~scroll container shadow seen in mockup is not implemented (yet). it's not a trivial thing and the [canonical pure CSS approach](https://lea.verou.me/2012/04/background-attachment-local/) doesn't work due to limitations around defined background colors~ discussed with Sabella and we can punt on this for now

---

Preview:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/18542095/234095719-69b83d8c-1159-41d5-ae95-e2a74a6e4869.png">