### PR TITLE
fix default layout issue caused by Andrew

### DIFF
--- a/src/renderer/src/layouts/default/index.tsx
+++ b/src/renderer/src/layouts/default/index.tsx
@@ -13,9 +13,7 @@ export const DefaultLayout = ({
 }) => {
   return (
     <Box minHeight="100vh" minWidth="100vw" sx={sx}>
-      <div style={{ zIndex: 1 }}>
-        <LanguageSwitcher langBackgroundVarient={langBackgroundVarient} />
-      </div>
+      <LanguageSwitcher langBackgroundVarient={langBackgroundVarient} />
       {children}
     </Box>
   )


### PR DESCRIPTION
I introduced this issue (see https://github.com/digidem/mapeo-desktop-shell/pull/23#discussion_r1169249006) but the problem it attempted to solve is irrelevant for now, so removing it entirely

example of the issue 😅 :

<img width="897" alt="image" src="https://user-images.githubusercontent.com/18542095/233408139-ae62e5fe-36da-4eb1-bd79-c779aa973844.png">
