### PR TITLE
use language tab as initial in settings

### DIFF
--- a/src/renderer/src/views/Home/Settings/index.tsx
+++ b/src/renderer/src/views/Home/Settings/index.tsx
@@ -71,7 +71,7 @@ const SettingsPanelContainer = styled.div(`
 `)
 
 export const Settings = () => {
-  const [activeTab, setActiveTab] = React.useState<SettingsTabName>('project')
+  const [activeTab, setActiveTab] = React.useState<SettingsTabName>('language')
 
   const { formatMessage: t } = useIntl()
 


### PR DESCRIPTION
I had set this to the project config tab mostly out of convenience for development since that's the only tab being tested. however, figuring that it makes more sense to change this to the language tab (which is listed first) for properly testing user flows