### PR TITLE
implement send invite flow

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -110,6 +110,9 @@
   "modals.joinProject.title": {
     "message": "Join Project"
   },
+  "view.Home.Settings.ProjectConfig.InviteDeviceModal.index.addAnotherDevice": {
+    "message": "Add Another Device"
+  },
   "views.Home.Settings.ProjectConfig.ConfigSection.config": {
     "message": "Config"
   },
@@ -127,9 +130,6 @@
   },
   "views.Home.Settings.ProjectConfig.ConfigSection.projectName": {
     "message": "Project Name"
-  },
-  "views.Home.Settings.ProjectConfig.InviteDeviceModal.Layout.cancel": {
-    "message": "Cancel"
   },
   "views.Home.Settings.ProjectConfig.InviteDeviceModal.Layout.title": {
     "message": "Invite Device"
@@ -163,6 +163,51 @@
   },
   "views.Home.Settings.ProjectConfig.InviteDeviceModal.SelectRole.selectRole": {
     "message": "Select a Role for this Device"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.acceptedMessage": {
+    "message": "Invite Accepted"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.asA": {
+    "message": "as a"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.coordinator": {
+    "message": "Coordinator"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.device": {
+    "message": "Device"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.inviting": {
+    "message": "You are inviting..."
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.participant": {
+    "message": "Participant"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.pendingMessage": {
+    "message": "Waiting for Device to Accept Invite"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.role": {
+    "message": "Role"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.sendInvite": {
+    "message": "Send Invite"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.status": {
+    "message": "Status"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.statusAccepted": {
+    "message": "Accepted!"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.statusPending": {
+    "message": "Pending..."
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.index.cancel": {
+    "message": "Cancel"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.index.cancelInvitation": {
+    "message": "Cancel Invitation"
+  },
+  "views.Home.Settings.ProjectConfig.InviteDeviceModal.index.close": {
+    "message": "Close"
   },
   "views.Home.Settings.ProjectConfig.ManageTeamSection.coordinator": {
     "message": "Coordinators"

--- a/src/renderer/src/hooks/stores/mapeoDeviceStore.ts
+++ b/src/renderer/src/hooks/stores/mapeoDeviceStore.ts
@@ -29,97 +29,107 @@ type MapeoDeviceState = {
   }
 }
 
-export const useMapeoDeviceStore = create<MapeoDeviceState>()((set) => ({
-  nonMemberDevices: createRandomDevices(4, 10),
-  memberDevices: createRandomMembers(createRandomDevices(3, 5, true)),
-  projectName: 'Catapult',
-  actions: {
-    addDeviceToProject: (deviceId, role) =>
-      set((state) => {
-        if (state.memberDevices[deviceId]) {
-          throw new Error(`Device is already part of the project`)
-        }
+export const useMapeoDeviceStore = create<MapeoDeviceState>()((set) => {
+  const { members, nonMembers } = createRandomDevices(6, 15)
+  return {
+    nonMemberDevices: nonMembers,
+    memberDevices: members,
+    projectName: 'Catapult',
+    actions: {
+      addDeviceToProject: (deviceId, role) =>
+        set((state) => {
+          if (state.memberDevices[deviceId]) {
+            throw new Error(`Device is already part of the project`)
+          }
 
-        const { [deviceId]: deviceToBeAdded, ...newNonMemberDevices } = state.nonMemberDevices
+          const { [deviceId]: deviceToBeAdded, ...newNonMemberDevices } = state.nonMemberDevices
 
-        if (!deviceToBeAdded) {
-          throw new Error(`Device does not exist`)
-        }
+          if (!deviceToBeAdded) {
+            throw new Error(`Device does not exist`)
+          }
 
-        return {
-          nonMemberDevices: newNonMemberDevices,
-          memberDevices: {
-            ...state.memberDevices,
-            [deviceId]: {
-              ...deviceToBeAdded,
-              role,
-              dateAdded: Date.now(),
+          return {
+            nonMemberDevices: newNonMemberDevices,
+            memberDevices: {
+              ...state.memberDevices,
+              [deviceId]: {
+                ...deviceToBeAdded,
+                role,
+                dateAdded: Date.now(),
+              },
             },
-          },
-        }
-      }),
-    removeDeviceFromProject: (deviceId) =>
-      set((state) => {
-        const { [deviceId]: deviceToBeRemoved, ...newMemberDevices } = state.memberDevices
+          }
+        }),
+      removeDeviceFromProject: (deviceId) =>
+        set((state) => {
+          const { [deviceId]: deviceToBeRemoved, ...newMemberDevices } = state.memberDevices
 
-        if (!deviceToBeRemoved) {
-          throw new Error(`Device is not part of the project`)
-        }
+          if (!deviceToBeRemoved) {
+            throw new Error(`Device is not part of the project`)
+          }
 
-        const { dateAdded, role, ...nonMemberDevice } = deviceToBeRemoved
+          const { dateAdded, role, ...nonMemberDevice } = deviceToBeRemoved
 
-        return {
-          memberDevices: newMemberDevices,
-          nonMemberDevices: { ...state.nonMemberDevices, [deviceId]: nonMemberDevice },
-        }
-      }),
-    changeDeviceRole: (deviceId, newRole) =>
-      set((state) => {
-        const deviceToBeChanged = state.memberDevices[deviceId]
+          return {
+            memberDevices: newMemberDevices,
+            nonMemberDevices: { ...state.nonMemberDevices, [deviceId]: nonMemberDevice },
+          }
+        }),
+      changeDeviceRole: (deviceId, newRole) =>
+        set((state) => {
+          const deviceToBeChanged = state.memberDevices[deviceId]
 
-        if (!deviceToBeChanged) {
-          throw new Error(`Device is not part of the project`)
-        }
+          if (!deviceToBeChanged) {
+            throw new Error(`Device is not part of the project`)
+          }
 
-        return {
-          memberDevices: { ...state.memberDevices, [deviceId]: { ...deviceToBeChanged, role: newRole } },
-        }
-      }),
-    setProjectName: (name) => set(() => ({ projectName: name })),
-  },
-}))
+          return {
+            memberDevices: { ...state.memberDevices, [deviceId]: { ...deviceToBeChanged, role: newRole } },
+          }
+        }),
+      setProjectName: (name) => set(() => ({ projectName: name })),
+    },
+  }
+})
 
 export const useMapeoDeviceStoreAction = () => useMapeoDeviceStore((store) => store.actions)
 
-function createRandomDevices(min: number, max: number, includeSelf = false) {
+function createRandomDevices(min: number, max: number) {
   const numberOfDevices = randomInteger(min, max)
-  let mapeoDevices: Record<string, Device> = {}
 
-  for (let i = 1; i <= numberOfDevices; i++) {
-    mapeoDevices[i] = {
-      name: `Peer ${i}`,
-      deviceId: i.toString(),
-      deviceType: Math.random() > 0.6 ? 'desktop' : 'mobile',
-      isSelf: (includeSelf && i === 1) || undefined,
-    }
-  }
-
-  return mapeoDevices
-}
-
-function createRandomMembers(devices: Record<string, Device>) {
+  const nonMembers: Record<string, Device> = {}
   const members: Record<string, MemberDevice> = {}
 
-  for (const id of Object.keys(devices)) {
-    const device = devices[id]
-    members[id] = {
-      ...device,
-      role: device.isSelf || Math.random() > 0.8 ? 'coordinator' : 'participant',
-      dateAdded: Date.now(),
+  for (let i = 1; i <= numberOfDevices; i++) {
+    // Always create at least one member and one non-member device
+    const isMember = i === 1 ? true : i === 2 ? false : Math.random() > 0.6
+
+    const deviceType = Math.random() > 0.75 ? 'desktop' : 'mobile'
+
+    const deviceInfo: Device = {
+      name: `Peer ${i}`,
+      deviceType,
+      deviceId: deviceType === 'mobile' ? `Android ${i}` : `Desktop ${i}`,
+    }
+
+    if (i === 1) {
+      deviceInfo.isSelf = true
+    }
+
+    if (isMember) {
+      const memberDeviceInfo: MemberDevice = {
+        ...deviceInfo,
+        role: deviceInfo.isSelf || Math.random() > 0.8 ? 'coordinator' : 'participant',
+        dateAdded: Date.now(),
+      }
+
+      members[memberDeviceInfo.deviceId] = memberDeviceInfo
+    } else {
+      nonMembers[deviceInfo.deviceId] = deviceInfo
     }
   }
 
-  return members
+  return { members, nonMembers }
 }
 
 function randomInteger(min: number, max: number) {

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal/Layout.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal/Layout.tsx
@@ -6,16 +6,19 @@ import { Row } from '@renderer/components/LayoutComponents'
 import { spacing } from '@renderer/theme/spacing'
 
 import { Text } from '../Text'
-import { Button } from '../Button'
 
 export const Layout = ({
   children,
   open,
+  primaryActionButton,
+  secondaryActionButton,
   onClose,
   onCloseEnd,
 }: React.PropsWithChildren<{
   open: boolean
   onClose: () => void
+  primaryActionButton: React.ReactNode
+  secondaryActionButton?: React.ReactNode
   onCloseEnd: () => void
 }>) => {
   const theme = useTheme()
@@ -52,9 +55,10 @@ export const Layout = ({
       </Row>
       <DialogContent sx={{ display: 'flex', padding: 0 }}>{children}</DialogContent>
       <DialogActions sx={{ borderTop: `1px solid ${theme.grey.light}`, paddingX: spacing.large }}>
-        <Button noBorder onClick={onClose}>
-          {t(m.cancel)}
-        </Button>
+        <Row spacing={spacing.large} alignItems="center">
+          {secondaryActionButton}
+          {primaryActionButton}
+        </Row>
       </DialogActions>
     </Dialog>
   )
@@ -64,9 +68,5 @@ const m = defineMessages({
   title: {
     id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.Layout.title',
     defaultMessage: 'Invite Device',
-  },
-  cancel: {
-    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.Layout.cancel',
-    defaultMessage: 'Cancel',
   },
 })

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal/SendInvite.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal/SendInvite.tsx
@@ -1,0 +1,247 @@
+import { defineMessages, useIntl } from 'react-intl'
+import { useTheme } from '@mui/material'
+import GroupIcon from '@mui/icons-material/Group'
+import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
+import SendIcon from '@mui/icons-material/Send'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import { Column, Row } from '@renderer/components/LayoutComponents'
+import { spacing } from '@renderer/theme/spacing'
+import { useMapeoDevice } from '@renderer/hooks/useMapeoDevice'
+import { Device, Role } from '@renderer/hooks/stores/mapeoDeviceStore'
+
+import desktopImageUrl from '../../../../../../assets/desktop.png'
+import mobileImageUrl from '../../../../../../assets/mobile.png'
+import { Text } from '../Text'
+import { Button, ButtonText } from '../Button'
+import { InviteStatus } from '.'
+import styled from '@emotion/styled'
+import { GREY_BLUE } from '@renderer/theme'
+
+export const SendInvite = ({
+  deviceId,
+  inviteStatus,
+  onSendInvite,
+  selectedRole,
+}: {
+  deviceId: string
+  inviteStatus: Extract<InviteStatus, 'idle' | 'pending' | 'accepted'>
+  onSendInvite: () => void
+  selectedRole: Role
+}) => {
+  const { device } = useMapeoDevice(deviceId)
+
+  return (
+    <Column flex={1} paddingY="72px" alignItems="center" spacing="48px" overflow="auto">
+      {inviteStatus === 'idle' ? (
+        <PreSendContent device={device} selectedRole={selectedRole} onSendInvite={onSendInvite} />
+      ) : inviteStatus === 'pending' || inviteStatus === 'accepted' ? (
+        <PostSendContent device={device} selectedRole={selectedRole} inviteStatus={inviteStatus} />
+      ) : null}
+    </Column>
+  )
+}
+
+const DeviceInfo = ({ deviceType, deviceId, name }: Pick<Device, 'deviceType' | 'deviceId' | 'name'>) => {
+  const theme = useTheme()
+  return (
+    <Row spacing={spacing.medium} alignItems="center">
+      <img
+        src={deviceType === 'desktop' ? desktopImageUrl : mobileImageUrl}
+        style={{ display: 'block', maxWidth: '100%', width: '40px' }}
+      />
+      <Column>
+        <Text size="medium" fontWeight="500">
+          {name}
+        </Text>
+        <Text size="small" color={theme.grey.main}>
+          {deviceId}
+        </Text>
+      </Column>
+    </Row>
+  )
+}
+
+const Circle = styled.div(`
+  padding: ${spacing.medium};
+  border: 1px solid ${GREY_BLUE};
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`)
+
+const PreSendContent = ({
+  device,
+  selectedRole,
+  onSendInvite,
+}: {
+  device: Device
+  selectedRole: Role
+  onSendInvite: () => void
+}) => {
+  const { formatMessage: t } = useIntl()
+  const theme = useTheme()
+
+  const RoleIcon = selectedRole === 'coordinator' ? ManageAccountsIcon : GroupIcon
+
+  return (
+    <>
+      <Row>
+        <Text size="large" fontWeight="500">
+          {t(m.inviting)}
+        </Text>
+      </Row>
+      <Row alignItems="center" justifyContent="center" spacing={spacing.large}>
+        <Column>
+          <DeviceInfo name={device.name} deviceType={device.deviceType} deviceId={device.deviceId} />
+        </Column>
+        <Column>
+          <Circle>
+            <Text size="small" color={theme.grey.main}>
+              {t(m.asA)}
+            </Text>
+          </Circle>
+        </Column>
+        <Row spacing={spacing.medium} alignItems="center">
+          <RoleIcon sx={{ fontSize: '36px' }} htmlColor={theme.black} />
+          <Text size="medium" fontWeight="500">
+            {t(selectedRole === 'coordinator' ? m.coordinator : m.participant)}
+          </Text>
+        </Row>
+      </Row>
+      <Row>
+        <Button
+          variant="contained"
+          disableElevation
+          noBorder
+          onClick={onSendInvite}
+          sx={{ backgroundColor: theme.blue.mid, color: theme.white }}
+        >
+          <Row alignItems="center" spacing={spacing.medium}>
+            <SendIcon color="inherit" />
+            <ButtonText>{t(m.sendInvite)}</ButtonText>
+          </Row>
+        </Button>
+      </Row>
+    </>
+  )
+}
+
+const PostSendContent = ({
+  device,
+  inviteStatus,
+  selectedRole,
+}: {
+  device: Device
+  inviteStatus: Extract<InviteStatus, 'pending' | 'accepted'>
+  selectedRole: Role
+}) => {
+  const { formatMessage: t } = useIntl()
+  const theme = useTheme()
+
+  const RoleIcon = selectedRole === 'coordinator' ? ManageAccountsIcon : GroupIcon
+
+  return (
+    <>
+      <Row>
+        <Column alignItems="center" spacing={spacing.large}>
+          {inviteStatus === 'pending' ? (
+            <SendIcon sx={{ fontSize: '72px' }} htmlColor={theme.blue.main} />
+          ) : (
+            <CheckCircleIcon sx={{ fontSize: '72px' }} htmlColor={theme.successGreen} />
+          )}
+          <Text size="large" fontWeight="500">
+            {t(inviteStatus === 'pending' ? m.pendingMessage : m.acceptedMessage)}
+          </Text>
+        </Column>
+      </Row>
+      <Row alignItems="flex-start" justifyContent="center" spacing="72px">
+        <Column alignItems="center" spacing={spacing.medium}>
+          <Text size="medium" fontWeight="500">
+            {t(m.device).toUpperCase()}
+          </Text>
+          <DeviceInfo name={device.name} deviceType={device.deviceType} deviceId={device.deviceId} />
+        </Column>
+        <Column alignItems="center" spacing={spacing.medium}>
+          <Text size="medium" fontWeight="500">
+            {t(m.role).toUpperCase()}
+          </Text>
+          <Row spacing={spacing.medium} alignItems="center">
+            <RoleIcon sx={{ fontSize: '36px' }} htmlColor={theme.black} />
+            <Text size="medium" fontWeight="500">
+              {t(selectedRole === 'coordinator' ? m.coordinator : m.participant)}
+            </Text>
+          </Row>
+        </Column>
+        <Column alignItems="center" spacing={spacing.medium}>
+          <Text size="medium" fontWeight="500">
+            {t(m.status).toLocaleUpperCase()}
+          </Text>
+          {inviteStatus === 'pending' ? (
+            <Text size="medium" color={theme.grey.main}>
+              {t(m.statusPending)}
+            </Text>
+          ) : (
+            <Row spacing={spacing.small} alignItems="center">
+              <CheckCircleIcon fontSize="medium" color="success" />
+              <Text size="medium" color={theme.successGreen}>
+                {t(m.statusAccepted)}
+              </Text>
+            </Row>
+          )}
+        </Column>
+      </Row>
+    </>
+  )
+}
+
+const m = defineMessages({
+  inviting: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.inviting',
+    defaultMessage: 'You are inviting...',
+  },
+  asA: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.asA',
+    defaultMessage: 'as a',
+  },
+  coordinator: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.coordinator',
+    defaultMessage: 'Coordinator',
+  },
+  participant: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.participant',
+    defaultMessage: 'Participant',
+  },
+  sendInvite: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.sendInvite',
+    defaultMessage: 'Send Invite',
+  },
+  pendingMessage: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.pendingMessage',
+    defaultMessage: 'Waiting for Device to Accept Invite',
+  },
+  acceptedMessage: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.acceptedMessage',
+    defaultMessage: 'Invite Accepted',
+  },
+  device: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.device',
+    defaultMessage: 'Device',
+  },
+  role: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.role',
+    defaultMessage: 'Role',
+  },
+  status: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.status',
+    defaultMessage: 'Status',
+  },
+  statusPending: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.statusPending',
+    defaultMessage: 'Pending...',
+  },
+  statusAccepted: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.SendInvite.statusAccepted',
+    defaultMessage: 'Accepted!',
+  },
+})

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal/index.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/InviteDeviceModal/index.tsx
@@ -1,25 +1,74 @@
 import * as React from 'react'
-import { Role } from '@renderer/hooks/stores/mapeoDeviceStore'
+import { defineMessages, useIntl } from 'react-intl'
+import { useTheme } from '@mui/material'
+import { Role, useMapeoDeviceStoreAction } from '@renderer/hooks/stores/mapeoDeviceStore'
 
+import { Button } from '../Button'
 import { Layout } from './Layout'
 import { SelectDevice } from './SelectDevice'
 import { SelectRole } from './SelectRole'
+import { SendInvite } from './SendInvite'
 
 type InviteStep =
   | { name: 'selectDevice' }
   | { name: 'selectRole'; deviceId: string }
   | { name: 'sendInvite'; deviceId: string; role: Role }
 
+export type InviteStatus = 'idle' | 'pending' | 'accepted' | 'declined' | 'error'
+
 export const InviteDeviceModal = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
+  const { formatMessage: t } = useIntl()
+  const theme = useTheme()
+  const { addDeviceToProject } = useMapeoDeviceStoreAction()
+
+  const [inviteStatus, setInviteStatus] = React.useState<InviteStatus>('idle')
+  const inviteTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
   const [step, setStep] = React.useState<InviteStep>({ name: 'selectDevice' })
+
+  const reachedFinalState = step.name === 'sendInvite' && inviteStatus === 'accepted'
+
+  function safeOnClose() {
+    if (inviteTimeoutRef.current) {
+      clearTimeout(inviteTimeoutRef.current)
+    }
+    onClose()
+  }
+
+  function resetModalState() {
+    setStep({ name: 'selectDevice' })
+    setInviteStatus('idle')
+  }
 
   return (
     <Layout
       open={open}
-      onClose={onClose}
-      onCloseEnd={() => {
-        setStep({ name: 'selectDevice' })
-      }}
+      onClose={safeOnClose}
+      onCloseEnd={resetModalState}
+      primaryActionButton={
+        <Button
+          noBorder
+          disableElevation
+          onClick={safeOnClose}
+          variant={reachedFinalState ? 'contained' : 'outlined'}
+          sx={reachedFinalState ? { backgroundColor: theme.blue.mid, color: theme.white } : undefined}
+        >
+          {t(getPrimaryButtonMessage(step.name, inviteStatus))}
+        </Button>
+      }
+      secondaryActionButton={
+        reachedFinalState ? (
+          <Button
+            variant="outlined"
+            noBorder
+            onClick={() => {
+              resetModalState()
+            }}
+          >
+            {t(m.addAnotherDevice)}
+          </Button>
+        ) : undefined
+      }
     >
       {step.name === 'selectDevice' ? (
         <SelectDevice
@@ -38,7 +87,58 @@ export const InviteDeviceModal = ({ open, onClose }: { open: boolean; onClose: (
             })
           }}
         />
+      ) : (step.name === 'sendInvite' && inviteStatus === 'idle') ||
+        inviteStatus === 'pending' ||
+        inviteStatus === 'accepted' ? (
+        <SendInvite
+          deviceId={step.deviceId}
+          selectedRole={step.role}
+          inviteStatus={inviteStatus}
+          onSendInvite={() => {
+            setInviteStatus('pending')
+            inviteTimeoutRef.current = setTimeout(() => {
+              addDeviceToProject(step.deviceId, step.role)
+              setInviteStatus('accepted')
+              inviteTimeoutRef.current = null
+            }, 3000)
+          }}
+        />
       ) : null}
     </Layout>
   )
 }
+
+function getPrimaryButtonMessage(stepName: InviteStep['name'], inviteStatus: InviteStatus) {
+  if (stepName === 'sendInvite') {
+    if (inviteStatus === 'pending') {
+      return m.cancelInvitation
+    }
+
+    if (inviteStatus === 'accepted') {
+      return m.close
+    }
+
+    return m.cancel
+  } else {
+    return m.cancel
+  }
+}
+
+const m = defineMessages({
+  cancel: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.index.cancel',
+    defaultMessage: 'Cancel',
+  },
+  cancelInvitation: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.index.cancelInvitation',
+    defaultMessage: 'Cancel Invitation',
+  },
+  close: {
+    id: 'views.Home.Settings.ProjectConfig.InviteDeviceModal.index.close',
+    defaultMessage: 'Close',
+  },
+  addAnotherDevice: {
+    id: 'view.Home.Settings.ProjectConfig.InviteDeviceModal.index.addAnotherDevice',
+    defaultMessage: 'Add Another Device',
+  },
+})


### PR DESCRIPTION
Closes #27
Closes #28

~**This is currently stacked on #55**~

Notes:

- also fixes the seeding implementation of the device store, which had issues caused by non-unique ids between member and non-member devices
- the sending icon used in the post-send pending state does not exist in the icon set we use, so it's using a plain send icon for now

Preview:

- Pre-send invite:

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/18542095/234447060-48cc971f-1dca-4530-a19b-90947bf4b85c.png">

- Post-send invite:

  - pending:
  
    <img width="1791" alt="image" src="https://user-images.githubusercontent.com/18542095/234447085-08285d0f-4e64-4426-a79b-bc8157ff0771.png">

  - accepted:
  
    <img width="1792" alt="image" src="https://user-images.githubusercontent.com/18542095/234447118-37ad9bd1-8d0b-4d37-97e5-2fab241d69a6.png">

- Post-success add another device (notice no more `Peer 2`)

<img width="897" alt="image" src="https://user-images.githubusercontent.com/18542095/234447146-49abba69-d2d9-4c7e-9563-99e4b710d2a6.png">
   
- Post-success close (see `Peer 2` under `Participants` section)

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/18542095/234447271-9ec4c818-ed8b-4dd7-b7ad-f73519f04ac2.png">
