### PR TITLE
convert app to (mostly) grayscale

### DIFF
--- a/src/renderer/src/components/App/index.tsx
+++ b/src/renderer/src/components/App/index.tsx
@@ -1,17 +1,17 @@
+import { CssBaseline, GlobalStyles } from '@mui/material'
 import { ThemeProvider } from '@mui/system'
 
+import { theme, OFF_BLACK, WHITE } from '../../theme'
 import { IntlProvider } from '../IntlProvider'
 import { Router } from '../Router'
-import { theme, OFF_BLACK as black, OFF_WHITE as white } from '../../theme'
-import { CssBaseline, GlobalStyles } from '@mui/material'
 import { fontFace } from './fontface'
 
 const GLOBAL_STYLES: React.ComponentProps<typeof GlobalStyles>['styles'] = [
   fontFace,
   {
     body: {
-      color: black,
-      backgroundColor: white,
+      color: OFF_BLACK,
+      backgroundColor: WHITE,
       fontFamily: `Rubik, Roboto, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', sans-serif;`,
     },
     svg: {

--- a/src/renderer/src/components/App/index.tsx
+++ b/src/renderer/src/components/App/index.tsx
@@ -6,25 +6,30 @@ import { theme, OFF_BLACK as black, OFF_WHITE as white } from '../../theme'
 import { CssBaseline, GlobalStyles } from '@mui/material'
 import { fontFace } from './fontface'
 
-const GLOBAL_STYLES = {
-  body: {
-    color: black,
-    backgroundColor: white,
-    fontFamily: `Rubik, Roboto, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', sans-serif;`,
+const GLOBAL_STYLES: React.ComponentProps<typeof GlobalStyles>['styles'] = [
+  fontFace,
+  {
+    body: {
+      color: black,
+      backgroundColor: white,
+      fontFamily: `Rubik, Roboto, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', sans-serif;`,
+    },
+    svg: {
+      filter: 'grayscale(1)',
+    },
   },
-  ...fontFace,
-}
+]
 
 function App() {
   return (
     <>
       <CssBaseline />
-      <GlobalStyles styles={GLOBAL_STYLES} />
-      <IntlProvider>
-        <ThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
+        <GlobalStyles styles={GLOBAL_STYLES} />
+        <IntlProvider>
           <Router />
-        </ThemeProvider>
-      </IntlProvider>
+        </IntlProvider>
+      </ThemeProvider>
     </>
   )
 }

--- a/src/renderer/src/components/App/index.tsx
+++ b/src/renderer/src/components/App/index.tsx
@@ -1,7 +1,7 @@
 import { CssBaseline, GlobalStyles } from '@mui/material'
 import { ThemeProvider } from '@mui/system'
 
-import { theme, OFF_BLACK, WHITE } from '../../theme'
+import { theme, OFF_BLACK, WHITE, WARNING_RED } from '../../theme'
 import { IntlProvider } from '../IntlProvider'
 import { Router } from '../Router'
 import { fontFace } from './fontface'
@@ -14,10 +14,20 @@ const GLOBAL_STYLES: React.ComponentProps<typeof GlobalStyles>['styles'] = [
       backgroundColor: WHITE,
       fontFamily: `Rubik, Roboto, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', sans-serif;`,
     },
-    svg: {
-      filter: 'grayscale(1)',
-    },
   },
+  // Converts all SVG elements to grayscale EXCEPT
+  // those built into various MUI form control elements reflecting an error state
+  `
+  svg {
+    filter: grayscale(1);
+  }
+  [class^=MuiFormControl] svg {
+    filter: unset;
+  }
+  [class^=MuiFormControl] .Mui-error svg {
+    color: ${WARNING_RED};
+  }
+  `,
 ]
 
 function App() {

--- a/src/renderer/src/components/CreateProjectModal/index.tsx
+++ b/src/renderer/src/components/CreateProjectModal/index.tsx
@@ -18,6 +18,7 @@ import { Button } from '../Button'
 import { FormLabel } from '../FormLabel'
 import { useNavigate } from 'react-router-dom'
 import { useMapeoDeviceStoreAction } from '@renderer/hooks/stores/mapeoDeviceStore'
+import { WARNING_RED } from '@renderer/theme'
 
 const PROJECT_NAME_MAX_LENGTH = 100
 const DEVICE_NAME_MAX_LENGTH = 60
@@ -146,14 +147,13 @@ export const CreateProjectModal = ({ open, onClose }: CreateProjectModalProps) =
               <FormLabel required>{intl.formatMessage(messages.question1)}</FormLabel>
               <RadioGroup value={teamMembersShouldBeVisible} onChange={handleTeamMembersVisibleChange}>
                 <FormControlLabel
-                  color="error"
                   value="yes"
-                  control={<Radio sx={shouldBeVisibleError ? { color: theme.warningRed } : {}} />}
+                  control={<Radio sx={shouldBeVisibleError ? { color: WARNING_RED } : {}} />}
                   label={intl.formatMessage(messages.yes)}
                 />
                 <FormControlLabel
                   value="no"
-                  control={<Radio sx={shouldBeVisibleError ? { color: theme.warningRed } : {}} />}
+                  control={<Radio sx={shouldBeVisibleError ? { color: WARNING_RED } : {}} />}
                   label={intl.formatMessage(messages.no)}
                 />
               </RadioGroup>

--- a/src/renderer/src/theme/index.ts
+++ b/src/renderer/src/theme/index.ts
@@ -1,18 +1,21 @@
 import { createTheme } from '@mui/material'
 import React from 'react'
 
-export const MAPEO_BLUE = '#0066FF'
-export const MAPEO_ORANGE = '#E86826'
 export const OFF_WHITE = '#F6F6F6'
 export const WHITE = '#FFFFFF'
 export const OFF_BLACK = '#333333'
-export const MIDNIGHT_BLUE = '#000033'
-export const MID_BLUE = '#19337F'
-export const WARNING_RED = '#D92222'
 export const GREY_LIGHT = '#E6E6E6'
 export const GREY = '#707070'
 export const GREY_BLUE = '#CCCCD6'
-export const GREEN = '#59A553'
+
+export const MAPEO_BLUE = GREY // '#0066FF'
+export const MAPEO_ORANGE = GREY // '#E86826'
+
+export const MIDNIGHT_BLUE = GREY // '#000033'
+export const MID_BLUE = GREY // '#19337F'
+export const WARNING_RED = '#D92222'
+
+export const GREEN = GREY // '#59A553'
 
 export const FONT_FAM_TITLE = `Rubik, Roboto, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', sans-serif;`
 export const FONT_FAM_BODY = `Roboto, Rubik, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', sans-serif;`

--- a/src/renderer/src/theme/index.ts
+++ b/src/renderer/src/theme/index.ts
@@ -1,6 +1,12 @@
 import { createTheme } from '@mui/material'
 import React from 'react'
 
+// Slightly lighter than GREY
+export const PLACEHOLDER_GREY_LIGHT = '#8C8C8C'
+
+// Slighter darker than GREY
+export const PLACEHOLDER_GREY_DARK = '#4C4C4C'
+
 export const OFF_WHITE = '#F6F6F6'
 export const WHITE = '#FFFFFF'
 export const OFF_BLACK = '#333333'
@@ -8,14 +14,14 @@ export const GREY_LIGHT = '#E6E6E6'
 export const GREY = '#707070'
 export const GREY_BLUE = '#CCCCD6'
 
-export const MAPEO_BLUE = GREY // '#0066FF'
-export const MAPEO_ORANGE = GREY // '#E86826'
+export const MAPEO_BLUE = PLACEHOLDER_GREY_LIGHT // '#0066FF'
+export const MAPEO_ORANGE = PLACEHOLDER_GREY_LIGHT // '#E86826'
 
-export const MIDNIGHT_BLUE = GREY // '#000033'
-export const MID_BLUE = GREY // '#19337F'
+export const MIDNIGHT_BLUE = PLACEHOLDER_GREY_DARK // '#000033'
+export const MID_BLUE = PLACEHOLDER_GREY_DARK // '#19337F'
 export const WARNING_RED = '#D92222'
 
-export const GREEN = GREY // '#59A553'
+export const GREEN = PLACEHOLDER_GREY_LIGHT // '#59A553'
 
 export const FONT_FAM_TITLE = `Rubik, Roboto, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', sans-serif;`
 export const FONT_FAM_BODY = `Roboto, Rubik, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', sans-serif;`
@@ -148,7 +154,9 @@ export const theme = createTheme({
   palette: {
     primary: { main: MAPEO_BLUE },
     secondary: { main: MID_BLUE },
-    warning: { main: WARNING_RED },
+    // Normally these should be WARNING_RED but using PLACEHOLDER_GREY_LIGHT for shell app purposes
+    warning: { main: PLACEHOLDER_GREY_LIGHT },
+    error: { main: PLACEHOLDER_GREY_LIGHT },
   },
   components: {
     MuiButtonBase: {

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/MemberManagmentModal/DeviceInfoContent/ConfirmRemoveDevice.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/MemberManagmentModal/DeviceInfoContent/ConfirmRemoveDevice.tsx
@@ -79,7 +79,8 @@ export const ConfirmRemoveDevice = ({ deviceId, closeModal, resetOnDelete }: Con
           noBorder
           disableElevation
           variant="contained"
-          sx={{ backgroundColor: theme.warningRed, color: theme.white }}
+          color="warning"
+          sx={{ backgroundColor: theme.blue.mid, color: theme.white }}
           onClick={handleRemoveDevice}
         >
           {t(m.removeDevice)}

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/MemberManagmentModal/DeviceInfoContent/DeviceInfo.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/MemberManagmentModal/DeviceInfoContent/DeviceInfo.tsx
@@ -175,7 +175,7 @@ export const DeviceInfo = ({ closeModal, deviceId, moveToConfirmationScreen }: D
           width: '100%',
         }}
       >
-        <Button noBorder variant="text" sx={{ color: theme.warningRed }} onClick={moveToConfirmationScreen}>
+        <Button noBorder variant="text" color="warning" onClick={moveToConfirmationScreen}>
           {t(m.removeDevice)}
         </Button>
         <Button

--- a/src/renderer/src/views/Home/Settings/ProjectConfig/MemberManagmentModal/LeaveProjectContent/LeaveProjectConfirmation.tsx
+++ b/src/renderer/src/views/Home/Settings/ProjectConfig/MemberManagmentModal/LeaveProjectContent/LeaveProjectConfirmation.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Typography } from '@mui/material'
+import { Checkbox, FormControlLabel, Typography } from '@mui/material'
 import ErrorIcon from '@mui/icons-material/Error'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
 import { Column, Row } from '../../../../../../components/LayoutComponents'
@@ -6,7 +6,7 @@ import { defineMessages, useIntl } from 'react-intl'
 import { Button } from '../../../../../../components/Button'
 import { MEDIA, OBSERVATIONS } from '@renderer/lib/Observations'
 import { useState } from 'react'
-import { theme } from '@renderer/theme'
+import { WARNING_RED, theme } from '@renderer/theme'
 import { useMapeoDeviceStore } from '@renderer/hooks/stores/mapeoDeviceStore'
 
 const m = defineMessages({
@@ -61,9 +61,9 @@ export const LeaveProjectConfirmation = ({ moveToDeleteDataContent, closeModal }
     moveToDeleteDataContent()
   }
 
-  function onClickCheckbox() {
+  function onClickCheckbox(checked: boolean) {
     if (error) setError(false)
-    setConfirmDelete((value) => !value)
+    setConfirmDelete(checked)
   }
 
   return (
@@ -95,22 +95,14 @@ export const LeaveProjectConfirmation = ({ moveToDeleteDataContent, closeModal }
             </Column>
           </Row>
           <Row alignItems={'center'}>
-            <Column>
-              <Checkbox
-                style={error ? { color: theme.warningRed } : undefined}
-                onClick={onClickCheckbox}
-                value={confirmDelete}
-              />
-            </Column>
-            <Column>
-              <Typography
-                style={error ? { color: theme.warningRed } : undefined}
-                variant="body1"
-                fontSize={16}
-              >
-                {t(m.checkConfirmation, { name: projectName })}
-              </Typography>
-            </Column>
+            <FormControlLabel
+              checked={confirmDelete}
+              componentsProps={error ? { typography: { sx: { color: WARNING_RED } } } : undefined}
+              onChange={(_event, checked) => onClickCheckbox(checked)}
+              control={<Checkbox sx={error ? { color: WARNING_RED } : undefined} />}
+              label={t(m.checkConfirmation, { name: projectName })}
+              value={confirmDelete}
+            />
           </Row>
         </Column>
       </Row>

--- a/src/renderer/src/views/Home/Settings/index.tsx
+++ b/src/renderer/src/views/Home/Settings/index.tsx
@@ -110,7 +110,7 @@ export const Settings = () => {
         <Tabs<SettingsTabName>
           activeTab={activeTab}
           onChangeTab={setActiveTab}
-          selectedColor={theme.grey.light}
+          selectedColor={theme.background}
           titleColor={theme.black}
           subtitleColor={theme.grey.main}
           data={tabsData}

--- a/src/renderer/src/views/Home/Settings/index.tsx
+++ b/src/renderer/src/views/Home/Settings/index.tsx
@@ -110,7 +110,7 @@ export const Settings = () => {
         <Tabs<SettingsTabName>
           activeTab={activeTab}
           onChangeTab={setActiveTab}
-          selectedColor={theme.background}
+          selectedColor={theme.grey.light}
           titleColor={theme.black}
           subtitleColor={theme.grey.main}
           data={tabsData}

--- a/src/renderer/src/views/Home/Sidebar.tsx
+++ b/src/renderer/src/views/Home/Sidebar.tsx
@@ -85,7 +85,7 @@ export const Sidebar = ({ activeTab, onChangeTab }: Props) => {
       <Tabs
         activeTab={activeTab}
         onChangeTab={onChangeTab}
-        selectedColor={`${theme.blue.dark}33`}
+        selectedColor={`${theme.black}33`}
         titleColor={theme.white}
         data={tabsData}
       />

--- a/src/renderer/src/views/MigratingProject/index.tsx
+++ b/src/renderer/src/views/MigratingProject/index.tsx
@@ -116,7 +116,7 @@ export const MigratingProjectView = () => {
             borderColor: theme.grey.light,
           }}
         >
-          <Link to="/migration-complete">
+          <Link to="/migration-complete" style={{ textDecoration: 'none' }}>
             <Button
               onClick={() => {}}
               variant="contained"

--- a/src/renderer/src/views/Migration/index.tsx
+++ b/src/renderer/src/views/Migration/index.tsx
@@ -48,7 +48,7 @@ export const MigrationView = () => {
             {intl.formatMessage(messages.skipMigration)}
           </Button>
           <Column alignItems="flex-end" spacing={1}>
-            <Link to="/migrating-project">
+            <Link to="/migrating-project" style={{ textDecoration: 'none' }}>
               <Button onClick={() => null} variant="contained" disableElevation>
                 {intl.formatMessage(messages.migrate)}
               </Button>

--- a/src/renderer/src/views/Migration/index.tsx
+++ b/src/renderer/src/views/Migration/index.tsx
@@ -44,7 +44,7 @@ export const MigrationView = () => {
         </Column>
         <DetailsCard projectKey={PROJECT_KEY} configAddress={CONFIG_ADDRESS} />
         <Row justifyContent="space-between" alignItems="flex-start">
-          <Button onClick={() => setSkipModalOpen(true)} variant="text" sx={{ color: theme.warningRed }}>
+          <Button color="warning" onClick={() => setSkipModalOpen(true)} variant="text">
             {intl.formatMessage(messages.skipMigration)}
           </Button>
           <Column alignItems="flex-end" spacing={1}>


### PR DESCRIPTION
Notes:

- Only applies color for error states (this DOES NOT include destructive buttons and their copy)
- also fixes application of global styles because I realized it was still broken 😓 
- Would HIGHLY recommend going through the whole app to check if I missed any spots

---

Preview:

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/18542095/234993113-be09456c-d204-4371-9c94-5e172b11d107.png">